### PR TITLE
feat(resource/streaming): set timeout length and return requested item on success

### DIFF
--- a/resource/streaming/client.lua
+++ b/resource/streaming/client.lua
@@ -1,57 +1,62 @@
-local function hasLoaded(fn, name)
-	local timeout = 0
+local function hasLoaded(fn, lType, name, limit)
+	local timeout = limit
 	while not fn(name) do
 		Wait(0)
-		timeout += 1
-		if timeout > 20 then return false end
+		if timeout then
+			timeout -= 1
+			if timeout == 0 then
+				print(('Unable to load %s after %s ticks (%s)'):format(lType, limit, name))
+				return false
+			end
+		end
 	end
-	return true
+	return name
 end
 
 ---@param dict string
+---@param timeout number
 --- Loads an animation dictionary.
-function lib.requestAnimDict(dict)
-	if HasAnimDictLoaded(dict) then return true end
+function lib.requestAnimDict(dict, timeout)
+	if HasAnimDictLoaded(dict) then return dict end
 	assert(DoesAnimDictExist(dict), ('Attempted to load an invalid animdict (%s)'):format(dict))
 	RequestAnimDict(dict)
-	if hasLoaded(HasAnimDictLoaded, dict) then return true end
-	print(('Unable to load animdict after 20 ticks (%s)'):format(dict))
+	return hasLoaded(HasModelLoaded, 'animdict', dict, timeout)
 end
 
 ---@param set string
+---@param timeout number
 --- Loads an animation clipset.
-function lib.requestAnimSet(set)
-	if HasAnimSetLoaded(set) then return true end
+function lib.requestAnimSet(set, timeout)
+	if HasAnimSetLoaded(set) then return set end
 	RequestAnimSet(set)
-	if hasLoaded(HasAnimSetLoaded, set) then return true end
-	print(('Unable to load animset after 20 ticks (%s)'):format(set))
+	return hasLoaded(HasModelLoaded, 'animset', set, timeout)
 end
 
 ---@param model string|number
+---@param timeout number
 --- Loads a model.
-function lib.requestModel(model)
-	model = type(model) == 'number' and model or joaat(model)
-	if HasModelLoaded(model) then return true end
+function lib.requestModel(model, timeout)
+	model = tonumber(model) or joaat(model)
+	if HasModelLoaded(model) then return model end
 	assert(IsModelValid(model), ('Attempted to load an invalid model (%s)'):format(model))
 	RequestModel(model)
-	if hasLoaded(HasModelLoaded, model) then return true end
-	print(('Unable to load model after 20 ticks (%s)'):format(model))
+	return hasLoaded(HasModelLoaded, 'model', model, timeout)
 end
 
 ---@param dict string
+---@param timeout number
 --- Loads a texture dictionary.
-function lib.requestStreamedTextureDict(dict)
-	if HasStreamedTextureDictLoaded(dict) then return true end
+function lib.requestStreamedTextureDict(dict, timeout)
+	if HasStreamedTextureDictLoaded(dict) then return dict end
 	RequestStreamedTextureDict(dict)
-	if hasLoaded(HasStreamedTextureDictLoaded, dict) then return true end
-	print(('Unable to load texture dict after 20 ticks (%s)'):format(dict))
+	return hasLoaded(HasModelLoaded, 'texture dict', dict, timeout)
 end
 
 ---@param fxName string
+---@param timeout number
 --- Loads a named particle effect.
-function lib.requestNamedPtfxAsset(fxName)
-	if HasNamedPtfxAssetLoaded(fxName) then return true end
+function lib.requestNamedPtfxAsset(fxName, timeout)
+	if HasNamedPtfxAssetLoaded(fxName) then return fxName end
 	RequestNamedPtfxAsset(fxName)
-	if hasLoaded(RequestNamedPtfxAsset, fxName) then return true end
-	print(('Unable to load named ptfx after 20 ticks (%s)'):format(fxName))
+	return hasLoaded(HasModelLoaded, 'named ptfx', fxName, timeout)
 end

--- a/resource/streaming/client.lua
+++ b/resource/streaming/client.lua
@@ -1,5 +1,5 @@
 local function hasLoaded(fn, type, request, limit)
-	timeout = limit or 100
+	local timeout = limit or 100
 	while not fn(request) do
 		Wait(0)
 		timeout -= 1

--- a/resource/streaming/client.lua
+++ b/resource/streaming/client.lua
@@ -1,16 +1,13 @@
-local function hasLoaded(fn, lType, name, limit)
-	local timeout = limit
-	while not fn(name) do
+local function hasLoaded(fn, type, request, limit)
+	timeout = limit or 100
+	while not fn(request) do
 		Wait(0)
-		if timeout then
-			timeout -= 1
-			if timeout == 0 then
-				print(('Unable to load %s after %s ticks (%s)'):format(lType, limit, name))
-				return false
-			end
+		timeout -= 1
+		if timeout < 1 then
+			return print(('Unable to load %s after %s ticks (%s)'):format(type, limit, request))
 		end
 	end
-	return name
+	return request
 end
 
 ---@param dict string


### PR DESCRIPTION
This is a bit of a mess since I've had it sitting around for about a month and I don't know how to split it up nicely at this point.

It's basically 2 parts:

- adds the timeout parameter 
allows the number of ticks before timeout to be specified, timeout is avoided if `nil`
20 ticks was rarely enough for vehicle spawns

- returns the requested item on success
basically just to return the vehicle hash so I don't have to `joaat` it twice
added to the other functions for consistency

I haven't tested the functions aside from `requestAnimDict` and `requestModel` but everything should still function